### PR TITLE
Make the find/replace collapsable

### DIFF
--- a/KevNotes/KevNotesToolWindowControl.xaml
+++ b/KevNotes/KevNotesToolWindowControl.xaml
@@ -10,7 +10,7 @@
              Name="MyToolWindow">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="25"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="*"></RowDefinition>
         </Grid.RowDefinitions>
@@ -22,6 +22,10 @@
             <Button x:Name="btnFontUp" Width="24" Height="24" MinWidth="24" MinHeight="24" Padding="0"
                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
                     Click="Button_Click_1">+</Button>
+            <Button x:Name="btnToggleTools" Width="24" Height="24" MinWidth="24" MinHeight="24" Padding="0"
+                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                    ToolTip="Collapse tools"
+                    Click="ToggleTools_Click">▲</Button>
         </StackPanel>
         <Border x:Name="FindBar" Grid.Row="1"
                 Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"

--- a/KevNotes/KevNotesToolWindowControl.xaml.cs
+++ b/KevNotes/KevNotesToolWindowControl.xaml.cs
@@ -32,6 +32,7 @@ namespace KevNotes
         private OutputWindowPane _outputPane;
         private bool _isLoading;
         private bool _isFormatting;
+        private bool _isToolsCollapsed;
         private bool _suppressFormatOnce;
         private string _lastUrlSignature = string.Empty;
         private string _lastTextSnapshot = string.Empty;
@@ -108,6 +109,7 @@ namespace KevNotes
                 {
                     btnFontDown.Style = buttonStyle;
                     btnFontUp.Style = buttonStyle;
+                    btnToggleTools.Style = buttonStyle;
                     btnFindNext.Style = buttonStyle;
                     btnReplace.Style = buttonStyle;
                     btnReplaceAll.Style = buttonStyle;
@@ -189,6 +191,7 @@ namespace KevNotes
                 {
                     SetCaretIndex(data.CaretIndex);
                 }
+                SetToolsCollapsed(data.IsToolsCollapsed ?? true);
 
                 if (data.FontFamily != null)
                 {
@@ -282,6 +285,7 @@ namespace KevNotes
                 CaretIndex = GetCaretIndex(),
                 FontFamily = rtbNotes.FontFamily,
                 FontSize = rtbNotes.FontSize,
+                IsToolsCollapsed = _isToolsCollapsed,
                 Note = NormalizeText(GetNoteText())
             };
         }
@@ -390,6 +394,24 @@ namespace KevNotes
         private void ReplaceAll_Click(object sender, RoutedEventArgs e)
         {
             ReplaceAll();
+        }
+
+        private async void ToggleTools_Click(object sender, RoutedEventArgs e)
+        {
+            SetToolsCollapsed(!_isToolsCollapsed);
+            rtbNotes.Focus();
+            await SaveAsync();
+        }
+
+        private void SetToolsCollapsed(bool isCollapsed)
+        {
+            _isToolsCollapsed = isCollapsed;
+
+            var toolsVisibility = isCollapsed ? Visibility.Collapsed : Visibility.Visible;
+            FindBar.Visibility = toolsVisibility;
+
+            btnToggleTools.Content = isCollapsed ? "▼" : "▲";
+            btnToggleTools.ToolTip = isCollapsed ? "Expand tools" : "Collapse tools";
         }
 
         private void ShowFindBar(bool showReplace)

--- a/KevNotes/NotesData.cs
+++ b/KevNotes/NotesData.cs
@@ -7,6 +7,7 @@ namespace KevNotes
         public FontFamily FontFamily { get; set; }
         public int CaretIndex { get; set; }
         public double FontSize { get; set; }
+        public bool? IsToolsCollapsed { get; set; }
         public string Note { get; set; }
     }
 }

--- a/KevNotes/Properties/AssemblyInfo.cs
+++ b/KevNotes/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.0")]

--- a/KevNotes/source.extension.vsixmanifest
+++ b/KevNotes/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="KevNotes.5e72f29c-4a9d-4543-9904-254ebbb26daa" Version="1.0.2" Language="en-US" Publisher="Kevin Butler" />
+        <Identity Id="KevNotes.5e72f29c-4a9d-4543-9904-254ebbb26daa" Version="1.0.3" Language="en-US" Publisher="Kevin Butler" />
         <DisplayName>KevNotes</DisplayName>
         <Description xml:space="preserve">A handy place in Visual Studio to keep quick notes</Description>
     </Metadata>


### PR DESCRIPTION
Add collapsible tools panel and persist state

Added a "Collapse tools" button to toggle the tools section (FindBar) in the tool window. Updated XAML layout and implemented logic to handle and persist the collapsed state using a new IsToolsCollapsed property in NotesData. Bumped version to 1.0.3.0.